### PR TITLE
Add all script files for YASS and BehaveNet analyses on NeuroCAAS.

### DIFF
--- a/behavenet/config_parser.py
+++ b/behavenet/config_parser.py
@@ -1,0 +1,74 @@
+import os
+import yaml 
+import argparse
+import sys
+
+MANDATORY_FILES = ['data', 'compute', 'model', 'training', 'params']
+FILE_TYPES = {
+    'data': 'hdf5',
+    'architecture': 'json',
+    'compute': 'json',
+    'model': 'json',
+    'training': 'json',
+    'params': 'json',
+    'sessions': 'csv'
+}
+
+FILE_FLAGS = {
+    'compute': '--compute_config',
+    'model': '--model_config',
+    'training': '--training_config',
+    'params': '--data_config'
+}
+
+
+def yaml_to_dict(filename):
+    try:
+        with open(filename) as f:
+            dictionary = yaml.full_load(f)
+        return dictionary
+    except:
+        sys.exit('failed to load {}'.format(filename))
+
+
+def formatted_print(metadict):
+    formatted = []
+    for filetype, name in metadict.items():
+        if name and not name.isspace() and name != '':
+            formatted.append('{}:{}'.format(filetype, name))
+
+    print(formatted)
+
+
+def check_data(metadata):
+    for mandatory in MANDATORY_FILES:
+        if mandatory not in metadata or not metadata[mandatory]:
+            sys.exit('missing mandatory file {}'.format(mandatory))
+
+    for filetype, filename in metadata.items():
+        try:
+            if filename and not filename.endswith('.{}'.format(FILE_TYPES[filetype])):
+                if filetype not in MANDATORY_FILES and filename == '':
+                    continue
+                else:
+                    sys.exit('{} is of an invalid file type for {} - should be .{}'.format(
+                        filename, filetype, FILE_TYPES[filetype]
+                    ))
+        except KeyError:
+            sys.exit('{} isn\'t supposed to be in here!'.format(filetype))
+
+
+def main(args):
+    metafile = args.meta[0]
+    metadata = yaml_to_dict(metafile)
+    check_data(metadata)
+    formatted_print(metadata)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'meta', help='meta.json with path', nargs=1)
+    args = parser.parse_args()
+
+    main(args)

--- a/behavenet/params_parser.py
+++ b/behavenet/params_parser.py
@@ -1,0 +1,65 @@
+import sys
+import shutil
+import json
+import argparse
+from pathlib import Path
+
+PARAMETERS = [
+    'lab',
+    'expt',
+    'animal',
+    'session',
+    'x_pixels',
+    'y_pixels',
+    'n_input_channels',
+    'use_output_mask',
+    'frame_rate',
+    'neural_type',
+    'neural_bin_size',
+    'approx_batch_size'
+]
+
+
+def json_to_dict(filename):
+    try:
+        with open(filename) as f:
+            dictionary = json.load(f)
+        return dictionary
+    except ValueError:
+        sys.exit('failed to load {}'.format(filename))
+
+
+def check_data(paramdata):
+    for param in PARAMETERS:
+        if param not in paramdata:
+            sys.exit('missing parameter {}'.format(param))
+
+
+def create_directory_structure(paramsdata, datafile, homedir):
+    datadir = json_to_dict(homedir)["data_dir"]
+    filepath = '{}/{}/{}/{}/{}'.format(
+        datadir, paramsdata['lab'], paramsdata['expt'], paramsdata['animal'], paramsdata['session'])
+    Path(filepath).mkdir(parents=True, exist_ok=True)
+    shutil.move(datafile, "{}/data.hdf5".format(filepath))
+    print("moved {} to {}/data.hdf5".format(datafile, filepath))
+
+def main(args):
+    paramsfile = args.params[0]
+    datafile = args.data[0]
+    dirfile = args.dir[0]
+    paramsdata = json_to_dict(paramsfile)
+    check_data(paramsdata)
+    create_directory_structure(paramsdata, datafile, dirfile)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'params', help='path to .json params file', nargs=1)
+    parser.add_argument(
+        'data', help='path to .hdf5 data file', nargs=1)
+    parser.add_argument(
+        'dir', help='path to directories.json file (in .behavenet in home dir)', nargs=1)
+    args = parser.parse_args()
+
+    main(args)

--- a/behavenet/run_behavenet.sh
+++ b/behavenet/run_behavenet.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+## Bash script that mocks real analysis. Just waits for one minute, then returns. 
+## Load in helper functions. 
+execpath="$0"
+echo execpath, $execpath
+scriptpath="$(dirname "$execpath")/ncap_utils"
+echo $scriptpath "SCRIPTPATH"
+source "$scriptpath/workflow.sh"
+## Import functions for data transfer 
+source "$scriptpath/transfer.sh"
+
+## Now parse arguments in to relevant variables: 
+# Bucket Name  $bucketname
+# Group Directory $groupdir 
+# Results Directory $resultdir
+# Dataset Name $dataname
+# Dataset Full Path $datapath
+# Configuration Name # configname
+# Configuration Path # configpath
+set -a
+parseargsstd "$1" "$2" "$3" "$4"
+set +a
+
+## Example usage:
+echo "$bucketname"/"$groupdir"/"$resultdir"/logs/DATASET_NAME:"$dataname"_STATUS.txt"" 
+## Set up Error Status Reporting:
+errorlog_init 
+
+## Set up STDOUT and STDERR Monitoring:
+errorlog_background & 
+background_pid=$!
+echo $background_pid, "is the pid of the background process"
+
+## MAIN SCRIPT GOES HERE #####################
+source /home/ubuntu/neurocaas_remote/run_behavenet_internal.sh
+##############################################
+errorlog_final
+kill "$background_pid"
+

--- a/behavenet/run_behavenet_internal.sh
+++ b/behavenet/run_behavenet_internal.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+## Import functions for workflow management 
+## Get the path to this function: 
+execpath="$0"
+scriptpath="$(dirname "$execpath")/ncap_utils"
+
+source "$scriptpath/workflow.sh"
+## Import functions for data transfer 
+source "$scriptpath/transfer.sh"
+
+## Set up error logging
+errorlog
+
+## Custom setup for this workflow
+source .dlamirc
+
+## Environment setup
+export PATH="/home/ubuntu/anaconda3/bin:$PATH"
+source activate nogamma 
+
+## Declare local storage locations:
+userhome="/home/ubuntu"
+datastore="$userhome/neurocaas_data"
+outstore="$userhome/neurocaas_output"
+accessdir "$datastore" "$outstore"
+
+## BehaveNet setup
+cd "$userhome/neurocaas_remote"
+
+## All JSON files in config go in .behavenet
+jsonstore="$userhome/.behavenet"
+
+## Make a second copy in .behavenet in root
+rootjsonstore="/root/.behavenet"
+
+## Download config file first
+aws s3 cp "s3://$bucketname/$configpath" "$userhome"
+
+## Parser will return an array of formatted strings representing key-value pairs 
+output=$(python config_parser.py "$userhome/config.json") 
+
+if [ $? != 0 ];
+then
+	echo "Error while parsing config, exiting..."
+	exit 1
+fi 
+
+FILES=($(echo $output | tr -d '[],'))
+
+for file in "${FILES[@]}" ; do
+    
+    file="${file%\'}"
+    file="${file#\'}"
+    FILETYPE="${file%:*}"
+    FILENAME="${file#*:}"
+
+    eval "$FILETYPE=$FILENAME"
+
+    if [[ "$FILETYPE" = "data" ]]
+    then
+	    ## Stereotyped download script for data
+	    aws s3 cp "s3://$bucketname/$(dirname "$inputpath")/${file#*:}" "$datastore"
+	    echo "Downloading data $FILENAME"
+    else
+	    ## Stereotyped download script for jsons
+	    aws s3 cp "s3://$bucketname/$(dirname "$inputpath")/${file#*:}" "$jsonstore"
+	    aws s3 cp "s3://$bucketname/$(dirname "$inputpath")/${file#*:}" "$rootjsonstore"
+	    echo "Downloading json $FILENAME"
+    fi
+
+done
+
+## Begin BehaveNet analysis
+echo "File downloads complete, beginning analysis..."
+output=$(python params_parser.py "$jsonstore/$params" "$datastore/$data" "$jsonstore/directories.json")
+
+if [ $? != 0 ];
+then
+	echo "Error while parsing $params, exiting..."
+	exit 1
+fi 
+
+cd "$userhome/no-gamma-behavenet"
+
+python behavenet/fitting/ae_grid_search.py --data_config "$jsonstore/$params" --model_config "$jsonstore/$model" --training_config "$jsonstore/$training" --compute_config "$jsonstore/$compute"
+
+cd "$userhome/neurocaas_remote"
+python run_hparam_search.py "$userhome/config.json" "$userhome"
+
+## Stereotyped upload script for output
+cd "$outstore"
+aws s3 sync ./ "s3://$bucketname/$groupdir/$processdir"
+cd "$userhome"

--- a/yass/parse_files.py
+++ b/yass/parse_files.py
@@ -1,0 +1,77 @@
+import os
+import yaml
+import argparse
+import sys
+
+# lists the files that are mandatory for the analysis to run
+MANDATORY_FILES = ["data", "geom", "config"]
+
+# maps the files required by the analysis to the correct file type
+FILE_TYPES = {
+    "data": ".bin",
+    "geom": [".npy", ".txt"],
+    "config": ".yaml"
+}
+
+
+def yaml_to_dict(file_name):
+    try:
+        with open(file_name) as f:
+            dictionary = yaml.full_load(f)
+        return dictionary
+    except:
+        sys.exit("Failed to load {}".format(file_name))
+
+
+# formats a dict as a list so the external bash script can parse the printed output
+def dict_to_bash_str(file_dict):
+    str_list = []
+    for file_type, file_name in file_dict.items():
+        if file_name and not file_name.isspace() and file_name != "":
+            str_list.append("{}:{}".format(file_type, file_name))
+
+    return ','.join(str_list)
+
+
+def check_data(file_data):
+    for mandatory in MANDATORY_FILES:
+        if mandatory not in file_data or not file_data[mandatory]:
+            sys.exit("Missing mandatory file {}".format(mandatory))
+
+    for file_type, file_name in file_data.items():
+        if file_name:
+            ext = os.path.splitext(file_name)[1]
+            try:
+                #
+                if ((type(FILE_TYPES[file_type]) == str and ext != FILE_TYPES[file_type]) or
+                        (type(FILE_TYPES[file_type]) == list and ext not in FILE_TYPES[file_type])):
+                    if file_type not in MANDATORY_FILES and file_name == "":
+                        continue
+                    else:
+                        sys.exit("{} is not a valid file type for {} - should be {}".format(
+                            file_name, file_type, FILE_TYPES[file_type]
+                        ))
+            except KeyError:
+                sys.exit("{} isn\'t supposed to be in here!".format(file_type))
+
+
+def main(args):
+    meta_data = yaml_to_dict(args.meta[0])
+    file_data = meta_data["files"]
+    option_data = meta_data["options"]
+
+    try:
+        check_data(file_data)
+    except KeyError:
+        sys.exit(
+            "Improperly formatted meta.json file. Check examples on the NeuroCAAS repository at "
+            "https://github.com/cunningham-lab/neurocaas_contrib")
+    print(dict_to_bash_str(file_data))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("meta", nargs=1)
+    parsed_args = parser.parse_args()
+
+    main(parsed_args)

--- a/yass/parse_options.py
+++ b/yass/parse_options.py
@@ -1,0 +1,70 @@
+import argparse
+import sys
+import copy
+
+from parse_files import yaml_to_dict, dict_to_bash_str, FILE_TYPES
+
+COMMAND_TEMPLATE = {
+    "retrain": {
+        "yes": "yass train \'config\'",
+        "no": "echo Using default neural networks ..."
+    },
+    "run": {
+        "yes": "yass sort \'config\'",
+        "no": "echo Doing nothing, goodbye!"
+    }
+}
+
+
+def check_options(options):
+    for action, option in options.items():
+        try:
+            test = COMMAND_TEMPLATE[action][option]
+        except KeyError:
+            sys.exit("{} is not a valid option for {}!".format(action, option))
+
+
+def substitute_file_names(command, file_data):
+    for file_type in FILE_TYPES:
+        try:
+            command = command.replace("\'{}\'".format(file_type), file_data[file_type])
+        except KeyError:
+            continue
+    return command
+
+
+def create_options_dict(files):
+    options_dict = copy.deepcopy(COMMAND_TEMPLATE)
+    for option in options_dict:
+        for setting in options_dict[option]:
+            options_dict[option][setting] = substitute_file_names(options_dict[option][setting], files)
+    return options_dict
+
+
+def replace_option_commands(options_data, options_dict):
+    for option in options_data:
+        options_data[option] = options_dict[option][options_data[option]]
+
+
+def main(args):
+    meta_data = yaml_to_dict(args.meta[0])
+    file_data = meta_data["files"]
+    option_data = meta_data["options"]
+
+    try:
+        check_options(option_data)
+    except KeyError:
+        sys.exit(
+            "Improperly formatted meta.json file. Check examples on the NeuroCAAS repository at "
+            "https://github.com/cunningham-lab/neurocaas_contrib")
+    options_dict = create_options_dict(file_data)
+    replace_option_commands(option_data, options_dict)
+    print(dict_to_bash_str(option_data))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("meta", nargs=1)
+    parsed_args = parser.parse_args()
+
+    main(parsed_args)

--- a/yass/run_yass.sh
+++ b/yass/run_yass.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+## Bash script that mocks real analysis. Just waits for one minute, then returns. 
+## Load in helper functions. 
+execpath="$0"
+echo execpath, $execpath
+scriptpath="$(dirname "$execpath")/ncap_utils"
+echo $scriptpath "SCRIPTPATH"
+source "$scriptpath/workflow.sh"
+## Import functions for data transfer 
+source "$scriptpath/transfer.sh"
+
+## Now parse arguments in to relevant variables: 
+# Bucket Name  $bucketname
+# Group Directory $groupdir 
+# Results Directory $resultdir
+# Dataset Name $dataname
+# Dataset Full Path $datapath
+# Configuration Name # configname
+# Configuration Path # configpath
+set -a
+parseargsstd "$1" "$2" "$3" "$4"
+set +a
+
+## Example usage:
+echo "$bucketname"/"$groupdir"/"$resultdir"/logs/DATASET_NAME:"$dataname"_STATUS.txt"" 
+## Set up Error Status Reporting:
+errorlog_init 
+
+## Set up STDOUT and STDERR Monitoring:
+errorlog_background & 
+background_pid=$!
+echo $background_pid, "is the pid of the background process"
+
+## MAIN SCRIPT GOES HERE #####################
+source /home/ubuntu/neurocaas_remote/run_yass_internal.sh
+##############################################
+errorlog_final
+kill "$background_pid"
+

--- a/yass/run_yass_internal.sh
+++ b/yass/run_yass_internal.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+## Import functions for workflow management. 
+## Get the path to this function: 
+execpath="$0"
+scriptpath="$(dirname "$execpath")/ncap_utils"
+
+source "$scriptpath/workflow.sh"
+## Import functions for data transfer 
+source "$scriptpath/transfer.sh"
+
+## Set up error logging. 
+errorlog
+
+## Custom setup for this workflow.
+source .dlamirc
+
+## Environment setup
+export PATH="/home/ubuntu/anaconda3/bin:$PATH"
+source activate yass
+
+## Declare local storage locations: 
+userhome="/home/ubuntu"
+scripthome="$userhome/neurocaas_remote"
+datastore="$userhome/yass/samples/localdata"
+outstore="$userhome/yass/samples/localdata/tmp"
+accessdir "$datastore" "$outstore"
+
+## Move into script directory
+cd "$scripthome"
+
+## Download config file first
+echo "Downloading config.json ..."
+aws s3 cp "s3://$bucketname/$configpath" "$scripthome"
+
+## Parser will return an array of formatted strings representing key-value pairs of file type and file name
+echo "Parsing files from config.json ..."
+file_output=$(python parse_files.py "$scripthome/config.json")
+
+if [ $? != 0 ];
+then
+	echo "Error while parsing config, exiting ..."
+	exit 1
+fi 
+
+IFS=',' read -ra FILES <<< "$file_output"
+
+for file in "${FILES[@]}" ; do
+    
+    FILETYPE="${file%:*}"
+    FILENAME="${file#*:}"
+
+    aws s3 cp "s3://$bucketname/$(dirname "$inputpath")/$FILENAME" "$datastore"
+    echo "Downloading file $FILENAME" to "$datastore"
+
+done
+
+## Another parser, this time returning key-value pairs of analysis options and bash commands
+echo "Parsing analysis options from config.json ..."
+option_output=$(python parse_options.py "$scripthome/config.json")
+
+if [ $? != 0 ];
+then
+	echo "Error while parsing config, exiting..."
+	exit 1
+fi
+
+IFS=',' read -ra OPTIONS <<< "$option_output"
+for option in "${OPTIONS[@]}" ; do
+    OPTION="${option%:*}"
+    COMMAND="${option#*:}"
+    echo "option is $OPTION, command is $COMMAND"
+    eval "$OPTION=\"$COMMAND\""
+
+done
+
+## Begin YASS analysis
+echo "File downloads complete, beginning analysis..."
+cd "$datastore"
+eval "$retrain"
+eval "$run"
+
+## Go to result directory
+cd "$outstore"
+aws s3 sync ./ "s3://$bucketname/$groupdir/$processdir"
+cd "$userhome"


### PR DESCRIPTION
The YASS (Yet Another Spike Sorter) and BehaveNet analyses require multiple dataset files with flexible extensions and names. In addition, they offer certain optional commands (or have other environment setup requirements) that require user input and cannot be done in an automated NeuroCAAS analysis. 

The current NeuroCAAS drag-n-drop interface only allows for a single dataset file for each analysis (selecting multiple dataset files launches a separate analysis instance for each file). However, all uploaded dataset files are available in the S3 bucket.

Use the config file to provide all filenames required for the analysis and analysis options, and upload those files as dataset files. Call Python scripts through the internal bash script to parse config file, download all specified dataset files, and run any desired optional commands. Since the config file specifies dataset filenames, selection of a dataset file in the NeuroCAAS web interface does not matter (can just choose any one). 