### PR TITLE
Bash scripts to use ncap-livestream

### DIFF
--- a/ncap_live/config_rtsp.yml
+++ b/ncap_live/config_rtsp.yml
@@ -1,0 +1,4 @@
+send: video
+cfg_filename: dlc_config.json
+path_cfg_file: Documents/DeepLabCut-live-GUI/config/
+model_file: DLC_Dog_resnet_50_iteration-0_shuffle-0.tar.gz

--- a/ncap_live/run_rtsp_zmq_cli.sh
+++ b/ncap_live/run_rtsp_zmq_cli.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+userhome="/home/ubuntu"
+datafolder="dlclive-data"
+project="DeepLabCut-live-GUI"
+
+datastore="$datafolder/model"
+configstore="$datafolder/config"
+echo $datastore,$configstore
+
+echo "----DOWNLOADING DATA----"
+neurocaas-contrib workflow get-data -f -o $userhome/$datastore/
+neurocaas-contrib workflow get-config -f -o $userhome/$configstore/
+
+datapath=$(neurocaas-contrib workflow get-datapath)
+configpath=$(neurocaas-contrib workflow get-configpath)
+echo "----DATA DOWNLOADED: $datapath. PARSING PARAMETERS.----"
+
+# Extract data and cfg file for DLCLive
+echo "----EXTRACTING ZIP DATA---- "
+unzip -o $datapath -d $userhome/$datastore
+pathcfgfile=$(neurocaas-contrib scripting read-yaml -p $configpath -f path_cfg_file)
+mv $userhome/$datastore/*.json $userhome/$pathcfgfile
+
+tarfile=$(neurocaas-contrib scripting read-yaml -p $configpath -f model_file)
+tar -xf "$userhome/$datastore/$tarfile" -C "$userhome/$datastore"
+echo "----EXTRACTED MODEL $tarfile FOR DLCLIVE.----"
+
+send=$(neurocaas-contrib scripting read-yaml -p $configpath -f send -d video)
+
+echo "----RUNNING DLCLIVE-GUI SERVER WITH RTSP ----"
+cd "$userhome/$project"
+xvfb-run python run_simulation.py stream-zmq --send $send
+
+# In case of want to finish process after some time
+# xvfb-run python run_simulation.py stream-zmq --send $send &
+# sleep 60
+# kill $(pgrep -f "xvfb-run python run_simulation.py stream-zmq --send $send")
+# echo "DONE"

--- a/ncap_live/run_rtsp_zmq_cli.sh
+++ b/ncap_live/run_rtsp_zmq_cli.sh
@@ -7,7 +7,6 @@ project="DeepLabCut-live-GUI"
 
 datastore="$datafolder/model"
 configstore="$datafolder/config"
-echo $datastore,$configstore
 
 echo "----DOWNLOADING DATA----"
 neurocaas-contrib workflow get-data -f -o $userhome/$datastore/

--- a/ncap_live/run_webrtc_cli.sh
+++ b/ncap_live/run_webrtc_cli.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+userhome="/home/ubuntu"
+datastore="neurocaas_webrtc/model"
+configstore="neurocaas_webrtc/config"
+
+echo "----DOWNLOADING DATA----"
+neurocaas-contrib workflow get-data -f -o $userhome/$datastore/
+neurocaas-contrib workflow get-config -f -o $userhome/$configstore/
+
+datapath=$(neurocaas-contrib workflow get-datapath)
+configpath=$(neurocaas-contrib workflow get-configpath)
+echo $datapath,$configpath,"$userhome/$datastore"
+taskname=$(tar -xvf "$datapath" -C "$userhome/$datastore")
+echo "----DATA DOWNLOADED: $datapath. PARSING PARAMETERS.----"
+
+echo "----RUNNING WEBRTC ----"
+cd "$userhome/neurocaas_webrtc"
+python server.py
+
+# In case of want to finish process after some time
+# python server.py &
+# sleep 60
+# kill $(pgrep -f 'python server.py')
+# echo "DONE"

--- a/ncap_live/run_webrtc_cli.sh
+++ b/ncap_live/run_webrtc_cli.sh
@@ -11,7 +11,6 @@ neurocaas-contrib workflow get-config -f -o $userhome/$configstore/
 
 datapath=$(neurocaas-contrib workflow get-datapath)
 configpath=$(neurocaas-contrib workflow get-configpath)
-echo $datapath,$configpath,"$userhome/$datastore"
 taskname=$(tar -xvf "$datapath" -C "$userhome/$datastore")
 echo "----DATA DOWNLOADED: $datapath. PARSING PARAMETERS.----"
 


### PR DESCRIPTION
# Bash script to run webrtc and rtsp in neurocaas pipeline

Bash scripts are created to run webrtc and rtsp on the ec2 server deployed by the neurocaas pipeline.

## Test locally

The test is performed on a local machine, in order to validate the operation of each script:
  - Download of the 'loaded' data to the s3 folder. This step emulates the process of uploading the files to the s3 bucket.
  - Execute each server. 

This requires to have installed the repos containing the solution of [webrtc](https://github.com/Monadical-SAS/neurocaas_webrtc) and [rtsp](https://github.com/Monadical-SAS/DeepLabCut-live-GUI/tree/rtmp-livestream) (in the `rtmp-livestream` branch).

The data used are:

 - DLCLive model: `DLC_Dog_resnet_50_iteration-0_shuffle-0.tar.gz`
 - Configuration file required by DLCLive:  `dlc_config,json`
 - Yaml configuration file to run RTSP: config_rtsp.yml
 - Configuration file read by the webrtc server. It is similar to the one used by dlclive:  `dlc_config,json`

Each of these configuration files are located in the repo of each solution.

### WEBRTC

To test webrtc locally, we proceeded as follows:

 - Create a temporal folder, s3 folder to save the pipeline process
```
mkdir tmp
mkdir -p s3/results
```
 - Initialize the job
```
neurocaas-contrib workflow initialize-job -p ./tmp
```

 - Register the dataset, config file and result path. You need to have the data model downloaded
```
neurocaas-contrib workflow register-dataset -l ./DLC_Dog_resnet_50_iteration-0_shuffle-0.tar.gz
neurocaas-contrib workflow register-config -l ./dlc_config.json
neurocaas-contrib workflow register-resultpath -l s3/results
```

 - Change permission to script
```
chmod 700 run_webrtc_local.sh
```

 - Run the script locally
```
neurocaas-contrib workflow log-command-local -c ./run_webrtc_local.sh
```


### RTSP

To test rtsp locally, we proceeded as follows:

 - Create a temporal folder, s3 folder to save the pipeline process
```
mkdir tmp
mkdir -p s3/results
```
 - Initialize the job
```
neurocaas-contrib workflow initialize-job -p ./tmp
```

 - Register the dataset, config file and result path. You need to have the data model downloaded.
   neurocaas_contrib only allows to register one data file and one configuration file. In this case, we need to manage a configuration file that allows to control the input parameters of the server script, as well as another configuration file that reads the server to manage other parameters. To implement this, the bash script that runs the server receives:

     - A yaml file as a configuration file (`config_rtsp.yml`):
    ```yaml
    send: video
    cfg_filename: dlc_config.json
    path_cfg_file: Documents/DeepLabCut-live-GUI/config/
    model_file: DLC_Dog_resnet_50_iteration-0_shuffle-0.tar.gz
    ```

    - A zip file (`rtsp_input.zip`) with the model data (`DLC_Dog_resnet_50_iteration-0_shuffle-0.tar.gz`) and the configuration file it requires (`dlc_config.json`). 
    
To register the files, we proceed in the same way
```
neurocaas-contrib workflow register-dataset -l rtsp_input.zip
neurocaas-contrib workflow register-config -l config_rtsp.yml
neurocaas-contrib workflow register-resultpath -l s3/results
```

 - Change permission to script
```
chmod 700 run_rtsp_zmq_local.sh
```

 - Run the script locally
```
neurocaas-contrib workflow log-command-local -c ./run_rtsp_zmq_local.sh
```


**NOTE** :
The difference between the files `run_*_cli.sh` (committed) and `run_*_local.sh` (mentioned here) is the path indicated in the `userhome` variable