### PR TITLE
added default option to be development security group

### DIFF
--- a/src/neurocaas_contrib/remote.py
+++ b/src/neurocaas_contrib/remote.py
@@ -216,7 +216,7 @@ class NeuroCAASAMI(object):
                  "MaxCount":1,
                  "DryRun":DryRun,
                  "KeyName":self.config["Lambda"]["LambdaConfig"]["KEY_NAME"],
-                 "SecurityGroups":[self.config["Lambda"]["LambdaConfig"]["SECURITY_GROUPS"]],#[gpdict["securitygroupdevname"]],
+                 "SecurityGroups":[self.config["Lambda"]["LambdaConfig"].get("SECURITY_GROUPS",gpdict["securitygroupdevname"])],#[],
                  "IamInstanceProfile":{'Name':self.config["Lambda"]["LambdaConfig"]["IAM_ROLE"]},
                  "TagSpecifications" : return_tags(timeout)
                  }

--- a/tests/test_mats/no_sg/stack_config_template.json
+++ b/tests/test_mats/no_sg/stack_config_template.json
@@ -12,7 +12,6 @@
             "AMI": "ami-6e7b06af",
             "INSTANCE_TYPE": "p3.2xlarge",
             "REGION": "us-east-1",
-            "SECURITY_GROUPS": "testsgstack-SecurityGroupDeploy-C2Q3PGSF77Y3",
             "IAM_ROLE": "SSMRole",
             "KEY_NAME": "testkeystack-custom-dev-key-pair",
             "WORKING_DIRECTORY": "~/bin",

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -34,9 +34,10 @@ class Test_NeuroCAASAMI():
     def test_init(self,mock_boto3_for_remote):
         ami = NeuroCAASAMI(os.path.join(test_mats))
 
-    def test_launch_devinstance(self,mock_boto3_for_remote):
+    @pytest.mark.parametrize("test_folder",[test_mats,os.path.join(test_mats,"no_sg")])
+    def test_launch_devinstance(self,mock_boto3_for_remote,test_folder):
         amiid = mock_boto3_for_remote
-        ami = NeuroCAASAMI(os.path.join(test_mats))
+        ami = NeuroCAASAMI(os.path.join(test_folder))
         ami.config["Lambda"]["LambdaConfig"]["AMI"] = amiid
         ami.launch_devinstance()
         ec2_client.terminate_instances(InstanceIds=[ami.instance.instance_id])


### PR DESCRIPTION
When launching an instance from a new template, will first look for the appropriate security group. If not given, will default to the *development* security group. 